### PR TITLE
Allow users to get direct shell access in apps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,21 @@ $ piku destroy
 $ piku # <- will show help for the remote app
 ```
 
-If you put this `piku` script on your `PATH` you can use the `piku` command across multiple apps on your local.
+You can pass flags through to the underlying SSH command, for example `-t` to run interactive commands remotely, and `-A` to proxy authentication credentials in order to do remote git pulls.
+
+Here is an example of using the `-t` flag to obtain a `bash` shell in the app directory of one of your Piku apps:
+
+```
+$ piku -t run bash
+Piku remote operator.
+Server: piku@cloud.mccormickit.com
+App: dashboard
+
+piku@piku:~/.piku/apps/dashboard$ ls
+data  ENV  index.html  package.json  package-lock.json  Procfile  server.wisp
+```
+
+Tip: If you put this `piku` script on your `PATH` you can use the `piku` command across multiple apps on your local.
 
 ### Installing other dependencies
 

--- a/piku
+++ b/piku
@@ -21,17 +21,24 @@ then
 else
   server=${PIKU_SERVER:-`echo $remote | cut -f1 -d":" 2>/dev/null`}
   app=${PIKU_APP:-`echo $remote | cut -f2 -d":" 2>/dev/null`}
+  # gather SSH flags
+  while [ "${1#\-}"x != "${1}x" ];
+  do
+    sshflags="${sshflags} ${1}"
+    shift
+  done
+  # check the Piku command to be run
   cmd="$1"
   out "Server: $server"
   out "App: $app"
   out
   case "$cmd" in
     apps|setup|setup:ssh|"")
-      ssh -A "$server" "$@"
+      ssh ${sshflags} "$server" "$@"
       ;;
     *)
       shift # remove cmd arg
-      ssh -A "$server" "$cmd" "$app" "$@"
+      ssh ${sshflags} "$server" "$cmd" "$app" "$@"
       ;;
   esac
 fi


### PR DESCRIPTION
This commit adds a small change to the `piku` script to pass through SSH
command flags, and documentation explaining how to use this to obtain a
remote shell on the piku server inside a running app folder.

tl;dr: `piku -t run bash` will give you shell in your app.