### PR TITLE
Fix letsencrypt renewal on HTTPS only sites.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -84,7 +84,9 @@ server {
     root ${ACME_WWW};
   }
 
-  return 301 https://$server_name$request_uri;
+  location / {
+    return 301 https://$server_name$request_uri;
+  }
 }
 
 server {


### PR DESCRIPTION
I noticed that `NGINX_HTTPS_ONLY=1` deploys were timing out during certificate renewal. This fixes it.