### PR TITLE
improvement: added optional <process> to logs also hid INTERNAL cmds.

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -145,9 +145,8 @@ Commands:
   destroy           Destroy an application
   disable           Disable an application
   enable            Enable an application
-  git-hook          INTERNAL: Post-receive git hook
-  git-receive-pack  INTERNAL: Handle git pushes for an app
   logs              Tail an application log
+  log               Tail an application log for a process
   ps                Show application worker count
   ps:scale          Show application configuration
   restart           Restart an application

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,7 +146,6 @@ Commands:
   disable           Disable an application
   enable            Enable an application
   logs              Tail an application log
-  log               Tail an application log for a process
   ps                Show application worker count
   ps:scale          Show application configuration
   restart           Restart an application

--- a/docs/old/RASPBERRY_PI_QUICKSTART.md
+++ b/docs/old/RASPBERRY_PI_QUICKSTART.md
@@ -139,8 +139,6 @@ Commands:
   destroy           Destroy an application
   disable           Disable an application
   enable            Enable an application
-  git-hook          INTERNAL: Post-receive git hook
-  git-receive-pack  INTERNAL: Handle git pushes for an app
   logs              Tail an application log
   ps                Show application worker count
   ps:scale          Show application configuration

--- a/piku.py
+++ b/piku.py
@@ -1138,17 +1138,18 @@ def cmd_destroy(app):
     
 @piku.command("logs")
 @argument('app')
-def cmd_logs(app):
-    """Tail running logs, e.g: piku logs <app>"""
+@argument('process', nargs=1, default='*')
+def cmd_logs(app, process):
+    """Tail running logs, e.g: piku logs <app> [<process>]"""
     
     app = exit_if_invalid(app)
 
-    logfiles = glob(join(LOG_ROOT, app, '*.log'))
+    logfiles = glob(join(LOG_ROOT, app, process + '.*.log'))
     if len(logfiles):
         for line in multi_tail(app, logfiles):
             echo(line.strip(), fg='white')
     else:
-        echo("No logs found for app '{}'.".format(app), fg='yellow')
+        echo("No logs found for app '{}'.".format(app), fg='yellow')\
 
 
 @piku.command("ps")
@@ -1300,7 +1301,7 @@ def cmd_stop(app):
         
 # --- Internal commands ---
 
-@piku.command("git-hook")
+@piku.command("git-hook", hidden=True)
 @argument('app')
 def cmd_git_hook(app):
     """INTERNAL: Post-receive git hook"""
@@ -1320,7 +1321,7 @@ def cmd_git_hook(app):
         do_deploy(app, newrev=newrev)
 
 
-@piku.command("git-receive-pack")
+@piku.command("git-receive-pack", hidden=True)
 @argument('app')
 def cmd_git_receive_pack(app):
     """INTERNAL: Handle git pushes for an app"""
@@ -1344,7 +1345,7 @@ cat | PIKU_ROOT="{PIKU_ROOT:s}" {PIKU_SCRIPT:s} git-hook {app:s}""".format(**env
     call('git-shell -c "{}" '.format(argv[1] + " '{}'".format(app)), cwd=GIT_ROOT, shell=True)
 
 
-@piku.command("git-upload-pack")
+@piku.command("git-upload-pack", hidden=True)
 @argument('app')
 def cmd_git_receive_pack(app):
     """INTERNAL: Handle git upload pack for an app"""

--- a/piku.py
+++ b/piku.py
@@ -1149,7 +1149,7 @@ def cmd_logs(app, process):
         for line in multi_tail(app, logfiles):
             echo(line.strip(), fg='white')
     else:
-        echo("No logs found for app '{}'.".format(app), fg='yellow')\
+        echo("No logs found for app '{}'.".format(app), fg='yellow')
 
 
 @piku.command("ps")


### PR DESCRIPTION
a couple of things:
- now it is possible to filter the logs with `piku logs <app> <process>`
- the INTERNAL commands are hidden from the `piku` help display
- removed the references to INTERNAL from some of the legacy documentation