### PR TITLE
Update piku cli from github

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -1381,5 +1381,23 @@ def cmd_help(ctx):
     echo(ctx.parent.get_help())
 
 
+@piku.command("update")
+def cmd_update():
+    """Update the piku cli"""
+    echo("Updating piku...")
+
+    with NamedTemporaryFile(mode="w") as f:
+        tempfile = f.name
+        cmd = """curl -sL -w %{{http_code}} https://raw.githubusercontent.com/piku/piku/master/piku.py -o {}""".format(tempfile)
+        response = check_output(cmd.split(' '), stderr=STDOUT)
+        http_code = response.decode('utf8').strip()
+        if http_code == "200":
+            copyfile(tempfile, PIKU_SCRIPT)
+            echo("Update successfully.")
+        else:
+            echo("Error updating piku cli.")
+    echo("Done.")
+
+
 if __name__ == '__main__':
     piku()


### PR DESCRIPTION
Once time Piku is installed in a server there is not an way to update the cli. So using 'update' client we have a non secure, but usefull cli updater. The command downloads piku.py from master branch to a temp file, if http return code is 200, its enough to supose that downloaded file is valid. We dont have file signature to validate.