### PR TITLE
Avoid install python2 each time at pre_task

### DIFF
--- a/playbooks/piku.yml
+++ b/playbooks/piku.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   pre_tasks:
     - name: Install python2 required by Ansible
-      raw: "( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || apt-get update && apt-get -y install python"
+      raw: "( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || ( apt-get update && apt-get -y install python )"
 
 - hosts: all
   become: yes


### PR DESCRIPTION
Python2 check, miss a parenthesis for apt-get and update.
```
( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || apt-get update && apt-get -y install python
```
becomes to
```
(( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || apt-get update ) && apt-get -y install python
```
so `apt-get -y install python` ever is executed even Python2 it's present

then we need to put update and install together
```
( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || ( apt-get  update && apt-get -y install python )
```