### PR TITLE
RFC: Build a single-binary deploy with pex.

### DIFF
--- a/binary/Makefile
+++ b/binary/Makefile
@@ -1,0 +1,17 @@
+VENV=./venv/bin/activate
+BIN=piku-gateway
+
+demo: $(VENV) ../piku.py
+	cp ../piku.py .
+	. $(VENV); pex . -r requirements.txt -c piku.py -o $(BIN) --python-shebang='#!/usr/bin/env python'
+	rm piku.py
+
+$(VENV): requirements.txt
+	test -d venv || virtualenv venv
+	. $(VENV); pip install -Ur requirements.txt
+	touch $(VENV)
+
+.PHONY: clean
+
+clean:
+	rm -rf $(BIN) venv

--- a/binary/requirements.txt
+++ b/binary/requirements.txt
@@ -1,0 +1,2 @@
+click
+pex

--- a/binary/setup.cfg
+++ b/binary/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/binary/setup.py
+++ b/binary/setup.py
@@ -1,0 +1,2 @@
+from distutils.core import setup
+setup(name='piku-binary', version='0.0.1', scripts=['piku.py'])


### PR DESCRIPTION
This experimental PR adds the ability to build a single-binary artifact of the Piku gateway script, avoiding the need to install deps (click).

The script can run on any version of Python on any architecture because Piku does not use any compiled deps.

Test it out by running `make` in the `binary` subdirectory and then you can run the resulting binary `piku-gateway` on any device with any version of Python installed.