### PR TITLE
Make Python virtualenv creation robust to existing env dir.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -557,9 +557,12 @@ def deploy_python(app, deltas={}):
     version = int(env.get("PYTHON_VERSION", "3"))
 
     first_time = False
-    if not exists(virtualenv_path):
+    if not exists(join(virtualenv_path, "bin", "activate")):
         echo("-----> Creating virtualenv for '{}'".format(app), fg='green')
-        makedirs(virtualenv_path)
+        try:
+            makedirs(virtualenv_path)
+        except FileExistsError:
+            echo("-----> Env dir already exists: '{}'".format(app), fg='yellow')
         call('virtualenv --python=python{version:d} {app:s}'.format(**locals()), cwd=ENV_ROOT, shell=True)
         first_time = True
 


### PR DESCRIPTION
This can be useful if the user starts with a static worker only and upgrades to a Python based deploy. The env dir will exist and this will prevent errors from being thrown when creating a Python virtualenv over the top.