### PR TITLE
Static serving resolves .html extension.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -168,6 +168,7 @@ INTERNAL_NGINX_STATIC_MAPPING = """
       directio 8m;
       aio threads;
       alias $static_path;
+      try_files $uri $uri.html $uri/ =404;
   }
 """
 


### PR DESCRIPTION
When serving static sites there is a general expectation that a bare URL like `/mypage` will automatically resolve to a .html extension like `/mypage.html` if the file exists. This is the norm for example on GitHub pages and Netlify, two popular static site hosting platforms. This patch adds a `try_files` clause to the static nginx config stanza to implement this behaviour by default when in static serving mode.