### PR TITLE
use PIKU_SERVER if not in a git repo

### DIFF
--- a/piku
+++ b/piku
@@ -8,6 +8,11 @@
 
 remote=`git config --get remote.piku.url`
 
+if [ "$remote" = "" ]
+then
+  remote=$PIKU_SERVER
+fi
+
 out() { printf "%s\n" "$*" >&2; }
 
 out "Piku remote operator."


### PR DESCRIPTION
Setting the PIKU_SERVER environment variable currently does not work:

```
riley@t480:~$ piku apps
Piku remote operator.

Error: no piku server configured.
Use PIKU_SERVER=piku@MYSERVER.NET or configure a git remote called 'piku'.

riley@t480:~$ PIKU_SERVER=piku@192.168.0.69 piku apps
Piku remote operator.

Error: no piku server configured.
Use PIKU_SERVER=piku@MYSERVER.NET or configure a git remote called 'piku'.
```

I noticed that the [piku](https://github.com/piku/piku/blob/master/piku) helper cli never checks for the var even though the output mentions it. This quick check should fix that.

```
riley@t480:~$ PIKU_SERVER=piku@192.168.0.69 piku apps
Piku remote operator.
Server: piku@192.168.0.69
App: piku@192.168.0.69

*<apps redacted>
```