### PR TITLE
add custom piku username / multiple users

### DIFF
--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -135,7 +135,7 @@ main() {
             echo "Using built-in playbook: ${playbook}"
             playbook="${builtin}"
           fi
-          PYTHONWARNINGS="ignore" ansible-playbook -i "${host}", "${playbook}" "$@"
+          PYTHONWARNINGS="ignore" ansible-playbook -i "${host}", "${playbook}" "$@" --extra-vars "piku_user=$PIKU_USER"
         else
           echo "${playbook} is not a valid playbook name."
         fi

--- a/playbooks/piku.yml
+++ b/playbooks/piku.yml
@@ -11,7 +11,7 @@
   tasks:
     - name: Add piku user
       user:
-        name: piku
+        name: "{{ piku_user | default('piku', true)}}"
         password: !
         comment: PaaS access
         group: www-data
@@ -72,7 +72,7 @@
 
 - hosts: all
   become: yes
-  become_user: piku
+  become_user: "{{ piku_user | default('piku', true)}}"
   tasks:
     ### TODO: use pyenv like this instead
 
@@ -111,6 +111,11 @@
       shell: python3 ~/piku.py setup:ssh /tmp/id_rsa.pub
       args:
         creates: ~/.ssh/authorized_keys
+
+    - name: Clean temp key
+      file:
+        state: absent
+        path: /tmp/id_rsa.pub
 
     - name: Check if acme.sh is already installed
       stat:


### PR DESCRIPTION
As I have begun using piku more and more, I found myself wanting some better logical separation for groups of applications running on the same server. This is my quick attempt at enabling a sort of pseudo-muti-tenancy.

# Changes made
- pass `piku_user` var to `piku` playbook.
- provision user as either value of `piku_user` or if none set, use default `piku`
- delete ssh key from /tmp
  - if you dont, running bootstrap a second time on same server fails as a different user tries to replace the key owned by the previous user

# Workflow

## Install under multiple users

eg. `PIKU_USER=<new user> ./piku-bootstrap <admin user>@192.168.0.72`

`PIKU_USER=riley ./piku-bootstrap jack@192.168.0.72`

`PIKU_USER=nicole ./piku-bootstrap jack@192.168.0.72`

## Deploy apps under multiple users

```
riley@t480:/tmp/sample-python-app$ git remote add piku riley@192.168.0.72:example

riley@t480:/tmp/sample-python-app$ git push piku master
Enumerating objects: 23, done.
Counting objects: 100% (23/23), done.
Delta compression using up to 8 threads
Compressing objects: 100% (20/20), done.
Writing objects: 100% (23/23), 13.86 KiB | 13.86 MiB/s, done.
Total 23 (delta 2), reused 21 (delta 1)
remote: -----> Creating app 'example'
remote: -----> Deploying app 'example'
remote: HEAD is now at e9d22ac Update README.md
remote: -----> Python app detected.
remote: -----> Creating virtualenv for 'example'
remote: Already using interpreter /usr/bin/python3
remote: Using base prefix '/usr'
remote: New python executable in /home/riley/.piku/envs/example/bin/python3
remote: Also creating executable in /home/riley/.piku/envs/example/bin/python
remote: Installing setuptools, pip, wheel...done.
remote: -----> Running pip for 'example'
remote: Collecting bottle
remote:   Using cached bottle-0.12.19-py3-none-any.whl (89 kB)
remote: Collecting APScheduler
remote:   Using cached APScheduler-3.7.0-py2.py3-none-any.whl (59 kB)
remote: Collecting pytz
remote:   Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
remote: Requirement already satisfied: setuptools>=0.7 in ./lib/python3.8/site-packages (from APScheduler->-r /home/riley/.piku/apps/example/requirements.txt (line 2)) (53.0.0)
remote: Collecting six>=1.4.0
remote:   Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
remote: Collecting tzlocal~=2.0
remote:   Using cached tzlocal-2.1-py2.py3-none-any.whl (16 kB)
remote: Installing collected packages: pytz, tzlocal, six, bottle, APScheduler
remote: Successfully installed APScheduler-3.7.0 bottle-0.12.19 pytz-2021.1 six-1.15.0 tzlocal-2.1
remote: -----> nginx NGINX_IPV4_ADDRESS set to 0.0.0.0
remote: -----> nginx NGINX_IPV6_ADDRESS set to [::]
remote: -----> spawning 'example:wsgi.1'
remote: -----> nginx will talk to uWSGI via 0.0.0.0:9080
remote: -----> spawning 'example:worker.1'
remote: -----> spawning 'example:clock.1'
To 192.168.0.72:example
 * [new branch]      master -> master

riley@t480:/tmp/sample-python-app$ piku apps
Piku remote operator.
Server: riley@192.168.0.72
App: example
Flags: 

*example

riley@t480:/tmp/sample-python-app$ git remote remove piku

riley@t480:/tmp/sample-python-app$ git remote add piku nicole@192.168.0.72:example

riley@t480:/tmp/sample-python-app$ git push piku master
Enumerating objects: 23, done.
Counting objects: 100% (23/23), done.
Delta compression using up to 8 threads
Compressing objects: 100% (20/20), done.
Writing objects: 100% (23/23), 13.86 KiB | 13.86 MiB/s, done.
Total 23 (delta 2), reused 21 (delta 1)
remote: -----> Creating app 'example'
remote: -----> Deploying app 'example'
remote: HEAD is now at e9d22ac Update README.md
remote: -----> Python app detected.
remote: -----> Creating virtualenv for 'example'
remote: Already using interpreter /usr/bin/python3
remote: Using base prefix '/usr'
remote: New python executable in /home/nicole/.piku/envs/example/bin/python3
remote: Also creating executable in /home/nicole/.piku/envs/example/bin/python
remote: Installing setuptools, pip, wheel...done.
remote: -----> Running pip for 'example'
remote: Collecting bottle
remote:   Downloading bottle-0.12.19-py3-none-any.whl (89 kB)
remote: Collecting APScheduler
remote:   Downloading APScheduler-3.7.0-py2.py3-none-any.whl (59 kB)
remote: Collecting six>=1.4.0
remote:   Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
remote: Collecting pytz
remote:   Downloading pytz-2021.1-py2.py3-none-any.whl (510 kB)
remote: Collecting tzlocal~=2.0
remote:   Downloading tzlocal-2.1-py2.py3-none-any.whl (16 kB)
remote: Requirement already satisfied: setuptools>=0.7 in ./lib/python3.8/site-packages (from APScheduler->-r /home/nicole/.piku/apps/example/requirements.txt (line 2)) (53.0.0)
remote: Installing collected packages: pytz, tzlocal, six, bottle, APScheduler
remote: Successfully installed APScheduler-3.7.0 bottle-0.12.19 pytz-2021.1 six-1.15.0 tzlocal-2.1
remote: -----> nginx NGINX_IPV4_ADDRESS set to 0.0.0.0
remote: -----> nginx NGINX_IPV6_ADDRESS set to [::]
remote: -----> spawning 'example:wsgi.1'
remote: -----> nginx will talk to uWSGI via 0.0.0.0:9080
remote: -----> spawning 'example:worker.1'
remote: -----> spawning 'example:clock.1'
To 192.168.0.72:example
 * [new branch]      master -> master

riley@t480:/tmp/sample-python-app$ piku apps
Piku remote operator.
Server: nicole@192.168.0.72
App: example
Flags: 

*example
```