### PR TITLE
Use letsencrypt by default and allow to change root ca with environme…

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -42,3 +42,7 @@ You can configure deployment settings by placing special variables in an `ENV` f
 * `NGINX_HTTPS_ONLY`: tell nginx to auto-redirect non-SSL traffic to SSL site
 * `NGINX_INCLUDE_FILE`: a file in the app's dir to include in nginx config `server` section - useful for including custom nginx directives.
 * `NGINX_ALLOW_GIT_FOLDERS`: (boolean) allow access to `.git` folders (default: false, blocked)
+
+## Acme Settings
+
+* `ACME_ROOT_CA`: set the certificate authority that Acme should use to generate public ssl certificates (string, default: `letsencrypt.org`)

--- a/piku.py
+++ b/piku.py
@@ -54,7 +54,7 @@ UWSGI_ROOT = abspath(join(PIKU_ROOT, "uwsgi"))
 UWSGI_LOG_MAXSIZE = '1048576'
 ACME_ROOT = environ.get('ACME_ROOT', join(environ['HOME'], '.acme.sh'))
 ACME_WWW = abspath(join(PIKU_ROOT, "acme"))
-ROOT_CA = environ.get('ROOT_CA', 'letsencrypt.org')
+ACME_ROOT_CA = environ.get('ACME_ROOT_CA', 'letsencrypt.org')
 
 # === Make sure we can access piku user-installed binaries === #
 
@@ -727,7 +727,7 @@ def spawn_app(app, deltas={}):
             if exists(join(ACME_ROOT, "acme.sh")):
                 acme = ACME_ROOT
                 www = ACME_WWW
-                root_ca = ROOT_CA
+                root_ca = ACME_ROOT_CA
                 # if this is the first run there will be no nginx conf yet
                 # create a basic conf stub just to serve the acme auth
                 if not exists(nginx_conf):

--- a/piku.py
+++ b/piku.py
@@ -54,6 +54,7 @@ UWSGI_ROOT = abspath(join(PIKU_ROOT, "uwsgi"))
 UWSGI_LOG_MAXSIZE = '1048576'
 ACME_ROOT = environ.get('ACME_ROOT', join(environ['HOME'], '.acme.sh'))
 ACME_WWW = abspath(join(PIKU_ROOT, "acme"))
+ROOT_CA = environ.get('ROOT_CA', 'letsencrypt.org')
 
 # === Make sure we can access piku user-installed binaries === #
 
@@ -726,6 +727,7 @@ def spawn_app(app, deltas={}):
             if exists(join(ACME_ROOT, "acme.sh")):
                 acme = ACME_ROOT
                 www = ACME_WWW
+                root_ca = ROOT_CA
                 # if this is the first run there will be no nginx conf yet
                 # create a basic conf stub just to serve the acme auth
                 if not exists(nginx_conf):
@@ -736,7 +738,7 @@ def spawn_app(app, deltas={}):
                 if not exists(key) or not exists(issuefile):
                     echo("-----> getting letsencrypt certificate")
                     certlist = " ".join(["-d {}".format(d) for d in domains])
-                    call('{acme:s}/acme.sh --issue {certlist:s} -w {www:s}'.format(**locals()), shell=True)
+                    call('{acme:s}/acme.sh --issue {certlist:s} -w {www:s} --server {root_ca:s}}'.format(**locals()), shell=True)
                     call('{acme:s}/acme.sh --install-cert {certlist:s} --key-file {key:s} --fullchain-file {crt:s}'.format(
                         **locals()), shell=True)
                     if exists(join(ACME_ROOT, domain)) and not exists(join(ACME_WWW, app)):


### PR DESCRIPTION
As stated [here](https://github.com/acmesh-official/acme.sh/wiki/ZeroSSL.com-CA), Acme.sh uses ZeroSSL as default CA, which requires a one time login and doesn't work out of the box with piku.

The proposed PR switches back to `letsencrypt.org as` default root CA and offers the possibility to force another CA using an environment variable.