### PR TITLE
Fix broken acme call

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -736,7 +736,7 @@ def spawn_app(app, deltas={}):
                 if not exists(key) or not exists(issuefile):
                     echo("-----> getting letsencrypt certificate")
                     certlist = " ".join(["-d {}".format(d) for d in domains])
-                    call('{acme:s}/acme.sh --issue {certlist:s} -w {www:s} --server {root_ca:s}}'.format(**locals()), shell=True)
+                    call('{acme:s}/acme.sh --issue {certlist:s} -w {www:s} --server {root_ca:s}'.format(**locals()), shell=True)
                     call('{acme:s}/acme.sh --install-cert {certlist:s} --key-file {key:s} --fullchain-file {crt:s}'.format(
                         **locals()), shell=True)
                     if exists(join(ACME_ROOT, domain)) and not exists(join(ACME_WWW, app)):


### PR DESCRIPTION
Not sure how this slipped past but commit bfec7c2d caused this regression when deploying a site with an SSL cert:

```
remote: Traceback (most recent call last):
remote:   File "/home/piku/piku.py", line 1530, in <module>
remote:     cli()
remote:   File "/usr/lib/python3/dist-packages/click/core.py", line 764, in __call__
remote:     return self.main(*args, **kwargs)
remote:   File "/usr/lib/python3/dist-packages/click/core.py", line 717, in main
remote:     rv = self.invoke(ctx)
remote:   File "/usr/lib/python3/dist-packages/click/core.py", line 1137, in invoke
remote:     return _process_result(sub_ctx.command.invoke(sub_ctx))
remote:   File "/usr/lib/python3/dist-packages/click/core.py", line 956, in invoke
remote:     return ctx.invoke(self.callback, **ctx.params)
remote:   File "/usr/lib/python3/dist-packages/click/core.py", line 555, in invoke
remote:     return callback(*args, **kwargs)
remote:   File "/home/piku/piku.py", line 1445, in cmd_git_hook
remote:     do_deploy(app, newrev=newrev)
remote:   File "/home/piku/piku.py", line 362, in do_deploy
remote:     settings.update(deploy_python(app, deltas))
remote:   File "/home/piku/piku.py", line 618, in deploy_python
remote:     return spawn_app(app, deltas)
remote:   File "/home/piku/piku.py", line 739, in spawn_app
remote:     call('{acme:s}/acme.sh --issue {certlist:s} -w {www:s} --server {root_ca:s}}'.format(**locals()), shell=True)
remote: ValueError: Single '}' encountered in format string
```

I hadn't upgraded my Piku server for a while so I missed this. Will try to keep it more current from now on.