### PR TITLE
Add multi-domain workaround due to ClickCommand.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -692,6 +692,10 @@ def spawn_app(app, deltas={}):
 
         # Set up nginx if we have NGINX_SERVER_NAME set
         if 'NGINX_SERVER_NAME' in env:
+            # Hack to get around ClickCommand
+            env['NGINX_SERVER_NAME'] = env['NGINX_SERVER_NAME'].split(',')
+            env['NGINX_SERVER_NAME'] = ' '.join(env['NGINX_SERVER_NAME'])
+
             nginx = command_output("nginx -V")
             nginx_ssl = "443 ssl"
             if "--with-http_v2_module" in nginx:


### PR DESCRIPTION
In practice, ClickCommand.argument splits based on spaces. I couldn't find a way to write `config:set NGINX_SERVER_NAME=server1 server2` and had to add this hack to allow for `config:set NGINX_SERVER_NAME=server1,server2`