### PR TITLE
issues/236 -- address DeprecationWarning in `click`

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -1109,8 +1109,10 @@ def piku():
     """The smallest PaaS you've ever seen"""
     pass
 
+
 piku.rc = getattr(piku, "resultcallback", None) or\
           getattr(piku, "result_callback", None)
+
 
 @piku.rc()
 def cleanup(ctx):

--- a/piku.py
+++ b/piku.py
@@ -1109,8 +1109,9 @@ def piku():
     """The smallest PaaS you've ever seen"""
     pass
 
+piku.rc = getattr(piku, "resultcallback") or getattr(piku, "result_callback")
 
-@piku.result_callback()
+@piku.rc()
 def cleanup(ctx):
     """Callback from command execution -- add debugging to taste"""
     pass

--- a/piku.py
+++ b/piku.py
@@ -1110,7 +1110,7 @@ def piku():
     pass
 
 
-@piku.resultcallback()
+@piku.result_callback()
 def cleanup(ctx):
     """Callback from command execution -- add debugging to taste"""
     pass

--- a/piku.py
+++ b/piku.py
@@ -1109,7 +1109,8 @@ def piku():
     """The smallest PaaS you've ever seen"""
     pass
 
-piku.rc = getattr(piku, "resultcallback") or getattr(piku, "result_callback")
+piku.rc = getattr(piku, "resultcallback", None) or\
+          getattr(piku, "result_callback", None)
 
 @piku.rc()
 def cleanup(ctx):

--- a/piku.py
+++ b/piku.py
@@ -1110,8 +1110,7 @@ def piku():
     pass
 
 
-piku.rc = getattr(piku, "resultcallback", None) or\
-          getattr(piku, "result_callback", None)
+piku.rc = getattr(piku, "resultcallback", None) or getattr(piku, "result_callback", None)
 
 
 @piku.rc()


### PR DESCRIPTION
In [`click==8.0.0`](https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-0), `MultiCommand.resultcallback` is renamed to `result_callback`, along with a deprecation warning. This change adopts the new naming convention.