### PR TITLE
Add bundle command use to VIRTUAL_ENV path

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -494,6 +494,7 @@ def deploy_ruby(app, deltas={}):
     if not exists(virtual):
         echo("-----> Building Ruby Application")
         makedirs(virtual)
+        call('bundle config set --local path $VIRTUAL_ENV', cwd=join(APP_ROOT, app), env=env, shell=True)       
     else:
         echo("------> Rebuilding Ruby Application")
 


### PR DESCRIPTION
A bundler install may attempt to use a path that requires sudoer privileges. This change configures the local setting of bundler to use the VIRTUAL_ENV dir, much as piku does for python.

Per https://bundler.io/man/bundle-config.1.html#REMEMBERING-OPTIONS, `bundle config set --local path` is the preferred way to set a gem path per project.

Hopefully this 1-liner is acceptably small to include upstream.

Note: without this change: the same config may be set in a Procfile `release` command. The problem is that the `release` command runs after the `bundle install` command in the `deploy_ruby` command. So the first push will always attempt a write to the wrong location. On the second deploy, it will succeed. This change would appear to improve the correctness of using bundler with piku.