### PR TITLE
For static hosting, first arg is root path

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -884,7 +884,7 @@ def spawn_app(app, deltas={}):
             # prepend static worker path if present
             if 'static' in workers:
                 stripped = workers['static'].strip("/").rstrip("/")
-                static_paths = "/:" + (stripped if stripped else ".") + "/" + ("," if static_paths else "") + static_paths
+                static_paths = ("/" if stripped[0:1] == ":" else "/:") + (stripped if stripped else ".") + "/" + ("," if static_paths else "") + static_paths
             if len(static_paths):
                 try:
                     items = static_paths.split(',')

--- a/piku.py
+++ b/piku.py
@@ -891,7 +891,7 @@ def spawn_app(app, deltas={}):
                     for item in items:
                         static_url, static_path = item.split(':')
                         if static_path[0] != '/':
-                            static_path = join(app_path, static_path)
+                            static_path = join(app_path, static_path).rstrip("/") + "/"
                         echo("-----> nginx will map {} to {}.".format(static_url, static_path))
                         env['PIKU_INTERNAL_NGINX_STATIC_MAPPINGS'] = env['PIKU_INTERNAL_NGINX_STATIC_MAPPINGS'] + expandvars(
                             PIKU_INTERNAL_NGINX_STATIC_MAPPING, locals())


### PR DESCRIPTION
Code assumed first argument to static workers is the root path, but the example incorrectly showed it to be a directory mapping.

This fix supports both: it adds “/“ if there is no mapping or else it accepts a mapping now. 

This also changes the example from the Procfile only pass the root directory. 

## Diagnosis

Error message from deploying the current static example:
```
remote: Error too many values to unpack (expected 2) in static path spec: should be /url1:path1[,/url2:path2], ignoring.
```

Static Procfile line parsing prepends the root path automatically.

https://github.com/piku/piku/blob/a433a68a1dd2d962033f44a818920a4c56899399/piku.py#L886

So the static path variable looks like this:
`['/::public', '/somepath:somedir/']`

Trailing "/" required after public or the path returns 403 errors when appending a second path.

Testing instructions:
You'll need to alter the githome var in piku to use this branches' `piku init` 
https://github.com/piku/piku/blob/a433a68a1dd2d962033f44a818920a4c56899399/piku#L12
becomes:
```
githome="https://raw.githubusercontent.com/ewalk153/piku/correct-static-assets-example/"
```
to test against this branch.

### Alternate approach

We could test to see if there is a colon in the first argument and only prepend the `/:` if it's not present. This should be backwards compatible as the current behavior is broken (breaks the deploy)
