### PR TITLE
Raise minimum python version to 3.7

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -4,13 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
       matrix:
-        # This is currently overkill since we are targeting 3.5
-        # but affords us visibility onto syntax changes in newer Pythons
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        # This range ensures coding standard does not conflict with 
+        #  changes in newer Pythons
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         # This range ensures coding standard does not conflict with 
         #  changes in newer Pythons
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/jammy/Dockerfile
+++ b/.github/workflows/jammy/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/os-packages.yml
+++ b/.github/workflows/os-packages.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        distro: [ buster, bionic, focal ]
+        distro: [ buster, jammy, focal ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/os-packages.yml
+++ b/.github/workflows/os-packages.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        distro: [ buster, jammy, focal ]
+        distro: [ buster, jammy, focal, bullseye ]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/ubuntu-22.04-jammy.md
+++ b/docs/ubuntu-22.04-jammy.md
@@ -1,8 +1,8 @@
-# Installation on Ubuntu 18.04 LTS (Bionic)
+# Installation on Ubuntu 22.04 LTS (Jammy)
 
 > This is a standalone, distribution-specific version of `INSTALL.md`. You do not need to read or follow the original file, but can refer to it for generic steps like setting up SSH keys (which are assumed to be common knowledge here)
 
-`piku` setup is simplified in Bionic, since it can take advantage of some packaging improvements in [uWSGI][uwsgi] and does not require a custom `systemd` service. Since Bionic also ships with Python 3.6, this is an ideal environment for new deployments on both Intel and ARM devices.
+`piku` setup is simplified in Jammy, since it can take advantage of some packaging improvements in [uWSGI][uwsgi] and does not require a custom `systemd` service. Since Jammy also ships with Python 3.10, this is an ideal environment for new deployments on both Intel and ARM devices.
 
 ## Dependencies
 
@@ -53,7 +53,7 @@ Setting '/home/piku/piku.py' as executable.
 
 ## uWSGI Configuration
 
-[uWSGI][uwsgi] in Bionic requires very little configuration, since it is already properly packaged. All you need to do is place a link to the `piku` configuration file in `/etc/uwsgi/apps-enabled`:
+[uWSGI][uwsgi] in Jammy requires very little configuration, since it is already properly packaged. All you need to do is place a link to the `piku` configuration file in `/etc/uwsgi/apps-enabled`:
 
 ```bash
 sudo ln /home/$PAAS_USERNAME/.piku/uwsgi/uwsgi.ini /etc/uwsgi/apps-enabled/piku.ini

--- a/docs/ubuntu-22.04-jammy.md
+++ b/docs/ubuntu-22.04-jammy.md
@@ -12,10 +12,10 @@ Before installing `piku`, you need to install the following packages:
 sudo apt-get update
 sudo apt-get install -y build-essential certbot git \
     libjpeg-dev libxml2-dev libxslt1-dev zlib1g-dev nginx \
-    python-certbot-nginx python-dev python-pip python-virtualenv \
+    python3-certbot-nginx \
     python3-dev python3-pip python3-click python3-virtualenv \
-    uwsgi uwsgi-plugin-asyncio-python3 uwsgi-plugin-gevent-python \
-    uwsgi-plugin-python uwsgi-plugin-python3 uwsgi-plugin-tornado-python
+    uwsgi uwsgi-plugin-asyncio-python3 uwsgi-plugin-gevent-python3 \
+    uwsgi-plugin-python3 uwsgi-plugin-tornado-python3
 ```
 ## Setting up the `piku` user
 

--- a/piku.py
+++ b/piku.py
@@ -4,9 +4,9 @@
 
 try:
     from sys import version_info
-    assert version_info >= (3, 5)
+    assert version_info >= (3, 7)
 except AssertionError:
-    exit("Piku requires Python 3.5 or above")
+    exit("Piku requires Python 3.7 or above")
 
 from importlib import import_module
 from collections import defaultdict, deque


### PR DESCRIPTION
- Ubuntu LTS (version 22) min python is now 3.7
- We get better formatters
- Latest version of click dropped support for Python 3.6

After this change, we can start a round of code cleaning in prep for a 1.0.

This change reverts the Ubuntu target to ubuntu-latest and drops 3.6 from the automated tests.

This partially addresses https://github.com/piku/piku/issues/227.

In the docs and docker images, we replace Ubuntu Bionic (18.04 LTS) with Ubuntu Jammy (22.04 LTS).