### PR TITLE
Add link to phoenix example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,4 +7,5 @@
  * [Clojure app with Lein](https://github.com/piku/sample-clojure-app)
  * [Node with Wisp](./nodejs-wisp)
  * [Golang](./golang) 
+ * [Phoenix App](https://github.com/axelbdt/piku-sample-phoenix-app)
 


### PR DESCRIPTION
Hi,
I tested deployment of an Elixir/Phoenix app a few months ago. Figured it could be added to the examples.
Feel free to clone the repo into the piku org and link to that if you prefer.
Cheers