### PR TITLE
Proxy scp so piku user can scp, and add 'download' local cmd.

### DIFF
--- a/piku
+++ b/piku
@@ -52,12 +52,17 @@ else
       ssh -o LogLevel=QUIET ${sshflags} "$server" "$@" | grep -v "INTERNAL"
       echo "  shell             Local command to start an SSH session in the remote."
       echo "  init              Local command to download an example ENV and Procfile."
+      echo "  download          Local command to scp down a remote file. args: REMOTE-FILE(s) LOCAL-PATH"
+      echo "                    Remote file path is relative to the app folder."
       ;;
     apps|setup|setup:ssh|update)
       ssh ${sshflags} "$server" "$@"
       ;;
     shell)
       ssh -t "$server" run "$app" bash
+      ;;
+    download)
+      scp "$server:~/.piku/apps/${app}/${2}" ${3:-'.'}
       ;;
     *)
       shift # remove cmd arg

--- a/piku.py
+++ b/piku.py
@@ -1649,6 +1649,13 @@ def cmd_git_upload_pack(app):
     call('git-shell -c "{}" '.format(argv[1] + " '{}'".format(app)), cwd=GIT_ROOT, shell=True)
 
 
+@piku.command("scp", context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))
+@pass_context
+def cmd_scp(ctx):
+    """Simple wrapper to allow scp to work."""
+    call(" ".join(["scp"] + ctx.args), cwd=GIT_ROOT, shell=True)
+
+
 def _get_plugin_commands(path):
     sys_path.append(abspath(path))
 


### PR DESCRIPTION
I frequently find I need to copy files to/from Piku apps. This patch adds the ability to scp using the piku user:

`scp myfile.txt piku@myserver.com:~/.piku/apps/someapp/`

Additionally it adds a new `download` command to the local `piku` script which automatically downloads from the currently configured app folder e.g.:

`piku download database.sqlite` will fetch the file to your local machine.

I haven't added a corresponding `upload` command because I got confused by the case of uploading multiple files and modifying the last arg to add the server (this was simple for download as it is in a fixed position). Will hopefully revisit that, but for now just being able to scp up should hopefully be useful enough.