### PR TITLE
Improves the accuracy of nginx configuration failure checking

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -974,7 +974,7 @@ def spawn_app(app, deltas={}):
                 h.write(buffer)
             # prevent broken config from breaking other deploys
             try:
-                nginx_config_test = str(check_output("nginx -t 2>&1 | grep {}".format(app), env=environ, shell=True))
+                nginx_config_test = str(check_output("nginx -t 2>&1 | grep -E '{}\.conf:[0-9]+$'".format(app), env=environ, shell=True))
             except Exception:
                 nginx_config_test = None
             if nginx_config_test:


### PR DESCRIPTION
I ran in to an issue trying to deploy an app called `test` with `piku`, as this keyword is present in the output of `nginx -t` every time, regardless of whether a validation error ocurred.

This pull request makes the `grep` check on the output of `nginx -t` match error lines more specifically to avoid this problem.