### PR TITLE
ISSUE-351: piku script works with multiple deploy targets

### DIFF
--- a/piku
+++ b/piku
@@ -6,7 +6,14 @@
 # git config --get remote.piku.url
 # git config --get remote.paas.url
 
-gitremote=`git config --get remote.piku.url`
+remote_name="piku"
+if [[ "$1" == "--remote" || "$1" == "-r" ]]; then
+  shift
+  remote_name="$1"
+  shift
+fi
+
+gitremote=`git config --get remote.$remote_name.url`
 remote=${gitremote:-"${PIKU_SERVER}:${PIKU_APP}"}
 
 githome="https://raw.githubusercontent.com/piku/piku/master/"


### PR DESCRIPTION
Without pulling argparse or optarg, this addition simply checks to see if the first argument specifies a remote, and accepts it. This makes no changes to the existing behavior, but may further complicate a TODO at the top of the file indicating there should be additional configuration sources.

Fixes: https://github.com/piku/piku/issues/351

Example Usage
```shell
$ piku shell  # works as usual
$ piku -r client run echo "Hello, world!"  # runs on the git remote named `client`
$ piku --remote server logs. # runs on the git remote named `server`
```