### PR TITLE
ISSUES-353: Show error message when no remote configured.

### DIFF
--- a/piku
+++ b/piku
@@ -34,7 +34,7 @@ fi
 
 out "Piku remote operator."
 
-if [ "$remote" = "" ]
+if [[ "$remote" = "" || "$remote" = ":" ]];
 then
   out
   out "Error: no piku server configured."


### PR DESCRIPTION
Fixes #353 . 

Before:
```
> piku
Piku remote operator.
Server:
App:

# hangs indefinitely....
```

After:
```
❯ piku
Piku remote operator.

Error: no piku server configured.
Use PIKU_SERVER=piku@MYSERVER.NET or configure a git remote called 'piku'.

```