### PR TITLE
ISSUES-354: Fix help subcommand in remote operator script

### DIFF
--- a/piku
+++ b/piku
@@ -55,7 +55,7 @@ else
   out "App: $app"
   out
   case "$cmd" in
-    "")
+    ""|help)
       ssh -o LogLevel=QUIET ${sshflags} "$server" "$@" | grep -v "INTERNAL"
       echo "  shell             Local command to start an SSH session in the remote."
       echo "  init              Local command to download an example ENV and Procfile."


### PR DESCRIPTION
Fixes #354 . 

Before:
```
❯ piku -r client help
Piku remote operator.
Server: piku@****
App: APPNAME

Usage: piku.py help [OPTIONS]
Try 'piku.py help --help' for help.

Error: Got unexpected extra argument (APPNAME)
```

After:
```
❯ piku -r client help
Piku remote operator.
Server: piku@****
App: ****

Usage: piku.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  apps              List apps, e.g.: piku apps
  config            Show config, e.g.: piku config <app>
  config:get        e.g.: piku config:get <app> FOO
  config:live       e.g.: piku config:live <app>
  config:set        e.g.: piku config:set <app> FOO=bar BAZ=quux
  config:unset      e.g.: piku config:unset <app> FOO
  deploy            e.g.: piku deploy <app>
  destroy           e.g.: piku destroy <app>
  help              display help for piku
  logs              Tail running logs, e.g: piku logs <app> [<process>]
  ps                Show process count, e.g: piku ps <app>
  ps:scale          e.g.: piku ps:scale <app> <proc>=<count>
  restart           Restart an app: piku restart <app>
  run               e.g.: piku run <app> ls -- -al
  scp               Simple wrapper to allow scp to work.
  setup             Initialize environment
  setup:ssh         Set up a new SSH key (use - for stdin)
  stop              Stop an app, e.g: piku stop <app>
  update            Update the piku cli
  shell             Local command to start an SSH session in the remote.
  init              Local command to download an example ENV and Procfile.
  download          Local command to scp down a remote file. args: REMOTE-FILE(s) LOCAL-PATH
                    Remote file path is relative to the app folder.
```