### PR TITLE
Adding support for catch-all URLs

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -71,6 +71,8 @@ Also, keep in mind that using `nginx` caching with a `static` website worker wil
 
 * `NGINX_INCLUDE_FILE`: a file in the app's dir to include in nginx config `server` section - useful for including custom `nginx` directives.
 * `NGINX_ALLOW_GIT_FOLDERS`: (boolean) allow access to `.git` folders (default: false, blocked)
+* `NGINX_CATCH_ALL` (string, defaults to ""): specifies a filename to serve to all requests regardless of path (useful when using client-side routing)
+
 
 ## Acme Settings
 

--- a/piku.py
+++ b/piku.py
@@ -171,7 +171,7 @@ PIKU_INTERNAL_NGINX_STATIC_MAPPING = """
       directio 8m;
       aio threads;
       alias $static_path;
-      try_files $uri $uri.html $uri/ =404;
+      try_files $uri $uri.html $uri/ $catch_all =404;
   }
 """
 
@@ -934,6 +934,8 @@ def spawn_app(app, deltas={}):
                 static_paths = ("/" if stripped[0:1] == ":" else "/:") + (stripped if stripped else ".") + "/" + ("," if static_paths else "") + static_paths
             if len(static_paths):
                 try:
+                    # pylint: disable=unused-variable
+                    catch_all = env.get('NGINX_CATCH_ALL', '')
                     items = static_paths.split(',')
                     for item in items:
                         static_url, static_path = item.split(':')


### PR DESCRIPTION
This PR adds support for serving all requests with the same filename. 

This is useful when using static sites and client-side routing as in react-router or ionic.