### PR TITLE
Make `piku` run under WSL

### DIFF
--- a/piku
+++ b/piku
@@ -6,6 +6,14 @@
 # git config --get remote.piku.url
 # git config --get remote.paas.url
 
+if grep -q WSL /proc/version 2>/dev/null
+then
+  # On WSL, use the Windows ssh.exe to benefit from 1Password integration
+  SSH="ssh.exe"
+else
+  SSH="ssh"
+fi
+
 remote_name="piku"
 if [ "$1" = "--remote" ] || [ "$1" = "-r" ]
 then
@@ -67,7 +75,7 @@ else
   out
   case "$cmd" in
     ""|help)
-      ssh -o LogLevel=QUIET "${sshflags}" "$server" "$@" | grep -v "INTERNAL"
+      $SSH -o LogLevel=QUIET "${sshflags}" "$server" "$@" | grep -v "INTERNAL"
       echo "  shell             Local command to start an SSH session in the remote."
       echo "  init              Local command to download an example ENV and Procfile."
       echo "  download          Local command to scp down a remote file. args: REMOTE-FILE(s) LOCAL-PATH"
@@ -75,10 +83,10 @@ else
       ;;
     apps|setup|setup:ssh|update)
       # shellcheck disable=SC2029 # caused by the final "$@", expanded on the client side
-      ssh "${sshflags}" "$server" "$@"
+      $SSH "${sshflags}" "$server" "$@"
       ;;
     shell)
-      ssh -t "$server" run "$app" bash
+      $SSH -t "$server" run "$app" bash
       ;;
     download)
       scp "$server:~/.piku/apps/${app}/${2}" "${3:-'.'}"
@@ -86,7 +94,7 @@ else
     *)
       shift # remove cmd arg
       # shellcheck disable=SC2029 # caused by the final "$@", expanded on the client side
-      ssh "${sshflags}" "$server" "$cmd" "$app" "$@"
+      $SSH "${sshflags}" "$server" "$cmd" "$app" "$@"
       ;;
   esac
 fi

--- a/piku
+++ b/piku
@@ -14,7 +14,7 @@ then
   shift
 fi
 
-gitremote=`git config --get remote.$remote_name.url`
+gitremote=$(git config --get remote."$remote_name".url)
 remote=${gitremote:-"${PIKU_SERVER}:${PIKU_APP}"}
 
 githome="https://raw.githubusercontent.com/piku/piku/master/"
@@ -23,8 +23,18 @@ out() { printf "%s\n" "$*" >&2; }
 
 if [ "$1" = "init" ]
 then
-  [ -f "ENV" ] && echo "ENV file already exists." || ( curl -s "${githome}examples/ENV" > ENV && echo "Wrote ./ENV file." )
-  [ -f "Procfile" ] && echo "Procfile already exists." || ( curl -s "${githome}examples/Procfile" > Procfile && echo "Wrote ./Procfile." )
+  if [ -f "ENV" ]
+  then
+    echo "ENV file already exists."
+  else
+    curl -s "${githome}examples/ENV" > ENV && echo "Wrote ./ENV file."
+  fi
+  if [ -f "Procfile" ]
+  then
+    echo "Procfile already exists."
+  else
+    curl -s "${githome}examples/Procfile" > Procfile && echo "Wrote ./Procfile."
+  fi
   if [ "$gitremote" = "" ]
   then
     echo "Now set up your piku remote for this app:"
@@ -42,8 +52,8 @@ then
   out "Use PIKU_SERVER=piku@MYSERVER.NET or configure a git remote called 'piku'."
   out
 else
-  server=`echo "$remote" | cut -f1 -d":" 2>/dev/null`
-  app=`echo "$remote" | cut -f2 -d":" 2>/dev/null`
+  server=$(echo "$remote" | cut -f1 -d":" 2>/dev/null)
+  app=$(echo "$remote" | cut -f2 -d":" 2>/dev/null)
   # gather SSH flags
   while [ "${1#\-}"x != "${1}x" ];
   do
@@ -57,24 +67,26 @@ else
   out
   case "$cmd" in
     ""|help)
-      ssh -o LogLevel=QUIET ${sshflags} "$server" "$@" | grep -v "INTERNAL"
+      ssh -o LogLevel=QUIET "${sshflags}" "$server" "$@" | grep -v "INTERNAL"
       echo "  shell             Local command to start an SSH session in the remote."
       echo "  init              Local command to download an example ENV and Procfile."
       echo "  download          Local command to scp down a remote file. args: REMOTE-FILE(s) LOCAL-PATH"
       echo "                    Remote file path is relative to the app folder."
       ;;
     apps|setup|setup:ssh|update)
-      ssh ${sshflags} "$server" "$@"
+      # shellcheck disable=SC2029 # caused by the final "$@", expanded on the client side
+      ssh "${sshflags}" "$server" "$@"
       ;;
     shell)
       ssh -t "$server" run "$app" bash
       ;;
     download)
-      scp "$server:~/.piku/apps/${app}/${2}" ${3:-'.'}
+      scp "$server:~/.piku/apps/${app}/${2}" "${3:-'.'}"
       ;;
     *)
       shift # remove cmd arg
-      ssh ${sshflags} "$server" "$cmd" "$app" "$@"
+      # shellcheck disable=SC2029 # caused by the final "$@", expanded on the client side
+      ssh "${sshflags}" "$server" "$cmd" "$app" "$@"
       ;;
   esac
 fi


### PR DESCRIPTION
This adds support for using [1Password's SSH integration under WSL](https://developer.1password.com/docs/ssh/integrations/wsl/). By using `ssh.exe`, the developer can use his fingerprint to connect to the remote server (otherwise the private key is not visible from Windows and it asks for the remote user's password).
I've also fixed almost all the shellcheck warnings present in the file. I didn't fix SC2029 cause I'm not sure about the original intentions of the author(s).