### PR TITLE
Use shlex.split to re-interpret SSH split args.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -19,6 +19,7 @@ from os.path import abspath, basename, dirname, exists, getmtime, join, realpath
 from pwd import getpwuid
 from grp import getgrgid
 from re import sub, match
+from shlex import split as shsplit
 from shutil import copyfile, rmtree, which
 from socket import socket, AF_INET, SOCK_STREAM
 from stat import S_IRUSR, S_IWUSR, S_IXUSR
@@ -1448,7 +1449,7 @@ def cmd_config_set(app, settings):
 
     config_file = join(ENV_ROOT, app, 'ENV')
     env = parse_settings(config_file)
-    for s in settings:
+    for s in shsplit(" ".join(settings)):
         try:
             k, v = map(lambda x: x.strip(), s.split("=", 1))
             env[k] = v


### PR DESCRIPTION
Fixes #297.

See the comments in #297 for details. Basically SSH splits on spaces when calling the `piku.py` subprocess *no matter what*. There's no way to stop it doing this. So you have to re-assemble the settings arguments, and split them again with `shlex.split()` which will properly parse everything as the user intended.

The end result is you can do this:

```
ssh piku@example.com config:set appname SOMEVAR="yes\ this\ works"
```

And Piku will then correctly write `SOMEVAR=yes this works` into the ENV file.

Related: https://hackaday.com/2023/07/15/ssh-can-handle-spaces-in-command-line-arguments-strangely/