### PR TITLE
Add multi-environment support

### DIFF
--- a/nginx.default.dist
+++ b/nginx.default.dist
@@ -25,4 +25,4 @@ server {
 		try_files $uri $uri/ =404;
 	}
 }
-include /home/piku/.piku/nginx/*.conf;
+include /home/piku*/.piku/nginx/*.conf;

--- a/piku-nginx.path
+++ b/piku-nginx.path
@@ -1,9 +1,0 @@
-[Unit]
-Description=Monitor .piku/nginx for changes
-
-[Path]
-PathChanged=/home/piku/.piku/nginx
-Unit=piku-nginx.service
-
-[Install]
-WantedBy=multi-user.target

--- a/piku-nginx@.path
+++ b/piku-nginx@.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Monitor .piku/nginx for changes (%i)
+
+[Path]
+PathChanged=/home/%i/.piku/nginx
+Unit=piku-nginx.service
+
+[Install]
+WantedBy=multi-user.target

--- a/piku.py
+++ b/piku.py
@@ -69,7 +69,7 @@ if PIKU_BIN not in environ['PATH']:
 # pylint: disable=anomalous-backslash-in-string
 NGINX_TEMPLATE = """
 $PIKU_INTERNAL_PROXY_CACHE_PATH
-upstream $APP {
+upstream $NGINX_UPSTREAM {
   server $NGINX_SOCKET;
 }
 server {
@@ -86,7 +86,7 @@ $PIKU_INTERNAL_NGINX_COMMON
 
 NGINX_HTTPS_ONLY_TEMPLATE = """
 $PIKU_INTERNAL_PROXY_CACHE_PATH
-upstream $APP {
+upstream $NGINX_UPSTREAM {
   server $NGINX_SOCKET;
 }
 server {
@@ -184,7 +184,7 @@ uwsgi_cache_path $cache_path levels=1:2 keys_zone=$app:20m inactive=$cache_time_
 
 PIKU_INTERNAL_NGINX_CACHE_MAPPING = """
     location ~* ^/($cache_prefixes) {
-        uwsgi_cache $APP;
+        uwsgi_cache $NGINX_UPSTREAM;
         uwsgi_cache_min_uses 1;
         uwsgi_cache_key $host$request_uri;
         uwsgi_cache_valid 200 304 $cache_time_content;
@@ -199,7 +199,7 @@ PIKU_INTERNAL_NGINX_CACHE_MAPPING = """
 """
 
 PIKU_INTERNAL_NGINX_UWSGI_SETTINGS = """
-    uwsgi_pass $APP;
+    uwsgi_pass $NGINX_UPSTREAM;
     uwsgi_param QUERY_STRING $query_string;
     uwsgi_param REQUEST_METHOD $request_method;
     uwsgi_param CONTENT_TYPE $content_type;
@@ -811,6 +811,7 @@ def spawn_app(app, deltas={}):
     # Bootstrap environment
     env = {
         'APP': app,
+        'NGINX_UPSTREAM': '{}_{}'.format(app, environ['USER']),
         'LOG_ROOT': LOG_ROOT,
         'DATA_ROOT': join(DATA_ROOT, app),
         'HOME': environ['HOME'],

--- a/uwsgi-piku@.service
+++ b/uwsgi-piku@.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Piku uWSGI Emperor
+Description=Piku uWSGI Emperor (%i)
 After=syslog.target
 
 [Service]
-ExecStart=/usr/local/bin/uwsgi-piku --ini /home/piku/.piku/uwsgi/uwsgi.ini
-User=piku
+ExecStart=/usr/local/bin/uwsgi-piku --ini /home/%i/.piku/uwsgi/uwsgi.ini
+User=%i
 Group=www-data
-RuntimeDirectory=uwsgi-piku
+RuntimeDirectory=uwsgi-%i
 Restart=always
 KillSignal=SIGQUIT
 Type=notify


### PR DESCRIPTION
Fixes #408

## Summary

Enable running multiple Piku environments (e.g., `piku-prod`, `piku-staging`) on the same server.

**Changes:**
- Add unique nginx upstream names with username suffix (`app_username`) to prevent conflicts when multiple envs have apps with the same name
- Use wildcard nginx include pattern (`/home/piku*/.piku/nginx/*.conf`) to load configs from all piku users
- Convert systemd files to templates using `%i` for instance name

## Breaking Changes

Existing installations need to:
1. Update nginx default config with wildcard include pattern
2. Re-enable systemd units with instance name: `systemctl enable uwsgi-piku@piku.service`